### PR TITLE
:zap: Support *. wildcard CORS origins

### DIFF
--- a/src/cors.ts
+++ b/src/cors.ts
@@ -46,7 +46,9 @@ export const cors = (options?: CorsOptions) => middleware({
   const origin = event.headers.get('origin')
   if (allowedOrigins.includes('*')) {
     event.reply.headers.set('access-control-allow-origin', '*')
-  } else if (origin && allowedOrigins.includes(origin)) {
+  } else if (origin
+    && (allowedOrigins.includes(origin)
+      || allowedOrigins.some(allowed => allowed.startsWith('*.') && origin.endsWith(allowed.slice(2))))) {
     event.reply.headers.set('access-control-allow-origin', origin)
     event.reply.headers.append('vary', 'origin')
   }

--- a/src/cors.ts
+++ b/src/cors.ts
@@ -48,7 +48,7 @@ export const cors = (options?: CorsOptions) => middleware({
     event.reply.headers.set('access-control-allow-origin', '*')
   } else if (origin
     && (allowedOrigins.includes(origin)
-      || allowedOrigins.some(allowed => allowed.startsWith('*.') && origin.endsWith(allowed.slice(2))))) {
+      || allowedOrigins.some(allowed => allowed.startsWith('*.') && origin.endsWith(allowed.slice(1))))) {
     event.reply.headers.set('access-control-allow-origin', origin)
     event.reply.headers.append('vary', 'origin')
   }


### PR DESCRIPTION
This should allow support for cors origins such as *.domain.com, allowing test.domain.com, test2.domain.com, but not domain.com.