### PR TITLE
:hammer: Fix semi-wildcard cors

### DIFF
--- a/src/cors.ts
+++ b/src/cors.ts
@@ -48,7 +48,7 @@ export const cors = (options?: CorsOptions) => middleware({
     event.reply.headers.set('access-control-allow-origin', '*')
   } else if (origin
     && (allowedOrigins.includes(origin)
-      || allowedOrigins.some(allowed => allowed.startsWith('https://*.') && origin.endsWith(allowed.slice(1))))) {
+      || allowedOrigins.some(allowed => allowed.startsWith('https://*.') && origin.endsWith(allowed.slice(9))))) {
     event.reply.headers.set('access-control-allow-origin', origin)
     event.reply.headers.append('vary', 'origin')
   }


### PR DESCRIPTION
Since the protocol is part of the origin (and we only want to allow `https://` origins), we need to splice that off as well, which adds another 8 characters to be sliced, together with the `*`.